### PR TITLE
Fix RA unsolicited spam

### DIFF
--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -680,7 +680,8 @@ static int construct_worker(struct in6_addr *local, int prefix,
 	    is_same_net6(local, &template->end6, template->prefix))
 	  {
 	    /* First time found, do fast RA. */
-	    if (template->if_index != if_index || !IN6_ARE_ADDR_EQUAL(&template->local6, local))
+	    if (template->if_index != if_index
+	        || !is_same_net6(&template->local6, local, template->prefix))
 	      {
 		ra_start_unsolicited(param->now, template);
 		param->newone = 1;


### PR DESCRIPTION
Original commit 0a496f059c1e9d75c33cce4c1211d58422ba4f62 introduced
floods of unsolicited RA spams. It loops between generated and assigned
address. Compare just subnet and does not check exact address.

[Fedora bug #1739797](https://bugzilla.redhat.com/show_bug.cgi?id=1739797)
[Mailing list thread](http://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2019q3/013255.html)