### PR TITLE
Report error on dhcp_release

### DIFF
--- a/contrib/lease-tools/dhcp_release.c
+++ b/contrib/lease-tools/dhcp_release.c
@@ -223,7 +223,11 @@ static struct in_addr find_interface(struct in_addr client, int fd, unsigned int
 	    ifr->ifr_addr.sa_family = AF_INET;
 	    if (ioctl(ifrfd, SIOCGIFADDR, ifr) != -1)
 	      return ((struct sockaddr_in *)&ifr->ifr_addr)->sin_addr;
-	    exit(0);
+	    else
+	      {
+		fprintf(stderr, "error: local IPv4 address not found\n");
+		exit(1);
+	      }
           }
 	else if (h->nlmsg_type == RTM_NEWADDR)
           {


### PR DESCRIPTION
If no IPv4 address is present on given interface, the tool would not
send any request. It would not report any error at the same time. Report
error if request send failed.

Signed-off-by: Petr Mensik <pemensik@redhat.com>